### PR TITLE
Fix typo in pipeline variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ MetaGEAR is an umbrella platform for high-throughput microbiome metagenomic anal
   A Nextflow/NF-Core pipeline that streamlines end-to-end microbiome metagenomic workflows—from raw reads to functional annotation.
 
 - **MetaGEAR Web**
-  A web application enabling interactive exploration of microbial gene functions in Inflammatory Bowel Disease (IBD) and Colorectal Cancer (CRC). Results from MetaGEAR Pipeline can be uploaded for seamless integration.
+  A web server enabling interactive exploration of microbial gene functions in Inflammatory Bowel Disease (IBD) and Colorectal Cancer (CRC). Results from MetaGEAR Pipeline can be uploaded for seamless integration.
 
 ---
 
@@ -20,10 +20,9 @@ MetaGEAR is an umbrella platform for high-throughput microbiome metagenomic anal
 
 ### Prerequisites
 
-- Java 8+
-- Nextflow 20.10.0+
-- Docker or Singularity
-- ≥ 16 GB RAM (for medium-size datasets)
+- [Java 11+](https://ubuntu.com/tutorials/install-jre#2-installing-openjdk-jre)
+- [Nextflow 22+](https://www.nextflow.io/docs/latest/install.html#install-page)
+- [Docker](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) or [Singularity](https://docs.sylabs.io/guides/3.0/user-guide/installation.html#install-the-debian-ubuntu-package-using-apt)
 
 ### Installation
 
@@ -49,13 +48,13 @@ metagear microbial_profiles --input=samples.csv
 The input file should look like this:
 ```
 sample,fastq_1,fastq_2
-SAMPLE-01,/path/to/fasta1_R1.fastq.gz,/path/to/fasta1_R2.fastq.gz
-SAMPLE-01,/path/to/fasta2_R1.fastq.gz,/path/to/fasta2_R2.fastq.gz
+SAMPLE-01,/path/to/sample1_R1.fastq.gz,/path/to/sample1_R2.fastq.gz
+SAMPLE-02,/path/to/sample2_R1.fastq.gz,/path/to/sample2_R2.fastq.gz
 ```
 
 ## 🌐 MetaGEAR Web
 
-Try it out live at: http://metagear.schirmerlab.de/
+Try it out live at: [http://metagear.schirmerlab.de](http://metagear.schirmerlab.de)
 
 MetaGEAR Web lets you:
 - Search microbial gene families by sequence or functional domains

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ metagear download_databases
 
 To run the QC and Microbial Profiles workflows, run:
 ```bash
-metagear qc_dna --input=samples.csv
-metagear microbial_profiles --input=samples.csv
+metagear qc_dna --input samples.csv
+metagear microbial_profiles --input samples.csv
 ```
 
 The input file should look like this:

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ MetaGEAR is an umbrella platform for high-throughput microbiome metagenomic anal
   A Nextflow/NF-Core pipeline that streamlines end-to-end microbiome metagenomic workflows—from raw reads to functional annotation.
 
 - **MetaGEAR Web**
-  A web application enabling interactive exploration of microbial gene functions in Inflammatory Bowel Disease (IBD) and Colorectal Cancer (CRC). Results from MetaGEAR Pipeline can be uploaded for seamless integration.
+  A web server enabling interactive exploration of microbial gene functions in Inflammatory Bowel Disease (IBD) and Colorectal Cancer (CRC). Results from MetaGEAR Pipeline can be uploaded for seamless integration.
 
 ---
 
@@ -25,10 +25,9 @@ MetaGEAR is an umbrella platform for high-throughput microbiome metagenomic anal
 
 ### Prerequisites
 
-- Java 8+
-- Nextflow 20.10.0+
-- Docker or Singularity
-- ≥ 16 GB RAM (for medium-size datasets)
+- [Java 11+](https://ubuntu.com/tutorials/install-jre#2-installing-openjdk-jre)
+- [Nextflow 22+](https://www.nextflow.io/docs/latest/install.html#install-page)
+- [Docker](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) or [Singularity](https://docs.sylabs.io/guides/3.0/user-guide/installation.html#install-the-debian-ubuntu-package-using-apt)
 
 ### Installation
 
@@ -54,13 +53,13 @@ metagear microbial_profiles --input=samples.csv
 The input file should look like this:
 ```
 sample,fastq_1,fastq_2
-SAMPLE-01,/path/to/fasta1_R1.fastq.gz,/path/to/fasta1_R2.fastq.gz
-SAMPLE-01,/path/to/fasta2_R1.fastq.gz,/path/to/fasta2_R2.fastq.gz
+SAMPLE-01,/path/to/sample1_R1.fastq.gz,/path/to/sample1_R2.fastq.gz
+SAMPLE-02,/path/to/sample2_R1.fastq.gz,/path/to/sample2_R2.fastq.gz
 ```
 
 ## 🌐 MetaGEAR Web
 
-Try it out live at: http://metagear.schirmerlab.de/
+Try it out live at: [http://metagear.schirmerlab.de](http://metagear.schirmerlab.de)
 
 MetaGEAR Web lets you:
 - Search microbial gene families by sequence or functional domains

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,8 +46,8 @@ metagear download_databases
 
 To run the QC and Microbial Profiles workflows, run:
 ```bash
-metagear qc_dna --input=samples.csv
-metagear microbial_profiles --input=samples.csv
+metagear qc_dna --input samples.csv
+metagear microbial_profiles --input samples.csv
 ```
 
 The input file should look like this:

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 INSTALL_DIR="${HOME}/.metagear"
 ORGANIZATION="schirmer-lab"
 PIPLINE_REPOSITORY="metagear-pipeline"
-PIPELINE_VERSION=0.1.0
+PIPELINE_VERSION=0.1.1
 UTILS_REPOSITORY="metagear"
 SCRIPT="main.sh"
 

--- a/install.sh
+++ b/install.sh
@@ -5,13 +5,13 @@ set -euo pipefail
 # 1) Config
 INSTALL_DIR="${HOME}/.metagear"
 ORGANIZATION="schirmer-lab"
-PIPLINE_REPOSITORY="metagear-pipeline"
+PIPELINE_REPOSITORY="metagear-pipeline"
 PIPELINE_VERSION=0.1.1
 UTILS_REPOSITORY="metagear"
 SCRIPT="main.sh"
 
 
-ZIP_URL="https://github.com/${ORGANIZATION}/${PIPLINE_REPOSITORY}/archive/refs/tags/${PIPELINE_VERSION}.zip"
+ZIP_URL="https://github.com/${ORGANIZATION}/${PIPELINE_REPOSITORY}/archive/refs/tags/${PIPELINE_VERSION}.zip"
 TMP_ZIP="${INSTALL_DIR}/downloads/metagear-${PIPELINE_VERSION}.zip"
 
 EXTRACTED_DIR="${INSTALL_DIR}/downloads/v${PIPELINE_VERSION}"
@@ -61,7 +61,7 @@ fi
 # 5) Unzip into place
 echo "→ Extracting to ${EXTRACTED_DIR}"
 unzip -qo "${TMP_ZIP}" -d "${EXTRACTED_DIR}"
-mv ${EXTRACTED_DIR}/${PIPLINE_REPOSITORY}-${PIPELINE_VERSION} ${PIPELINE_DIR}
+mv ${EXTRACTED_DIR}/${PIPELINE_REPOSITORY}-${PIPELINE_VERSION} ${PIPELINE_DIR}
 
 ln -s ${PIPELINE_DIR} ${INSTALL_DIR}/latest
 


### PR DESCRIPTION
## Summary
- fix variable name in install script from `PIPLINE_REPOSITORY` to `PIPELINE_REPOSITORY`

## Testing
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f7cc239188323bbb90100286ddde3