### PR TITLE
Add bats tests & conditional input

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ SAMPLE-01,/path/to/sample1_R1.fastq.gz,/path/to/sample1_R2.fastq.gz
 SAMPLE-02,/path/to/sample2_R1.fastq.gz,/path/to/sample2_R2.fastq.gz
 ```
 
+### Running tests
+
+To verify CLI behavior, run the Bats suite:
+
+```bash
+bats tests
+```
+
 ## 🌐 MetaGEAR Web
 
 Try it out live at: [http://metagear.schirmerlab.de](http://metagear.schirmerlab.de)

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,14 @@ SAMPLE-01,/path/to/sample1_R1.fastq.gz,/path/to/sample1_R2.fastq.gz
 SAMPLE-02,/path/to/sample2_R1.fastq.gz,/path/to/sample2_R2.fastq.gz
 ```
 
+### Running tests
+
+Run the Bats suite to ensure everything works as expected:
+
+```bash
+bats tests
+```
+
 ## 🌐 MetaGEAR Web
 
 Try it out live at: [http://metagear.schirmerlab.de](http://metagear.schirmerlab.de)

--- a/lib/workflows.sh
+++ b/lib/workflows.sh
@@ -76,6 +76,12 @@ function run_workflows() {
 
     mkdir -p "$outdir"
 
-    echo "--workflow $workflow --input $default_input_file --outdir $outdir"
+    cmd="--workflow $workflow"
+    if [[ "${require_input[$workflow]}" == "true" ]]; then
+        cmd+=" --input $default_input_file"
+    fi
+    cmd+=" --outdir $outdir"
+
+    echo "$cmd"
 }
 

--- a/tests/workflows.bats
+++ b/tests/workflows.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+
+load '../lib/workflows.sh'
+
+@test "download_databases omits --input" {
+  result="$(run_workflows download_databases)"
+  [[ "$result" != *"--input"* ]]
+}
+
+@test "qc_dna includes --input" {
+  result="$(run_workflows qc_dna)"
+  [[ "$result" == *"--input"* ]]
+}


### PR DESCRIPTION
## Summary
- test workflow helper functions with bats
- avoid adding `--input` for workflows without required input
- document how to run bats tests

## Testing
- `bats tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7b9494348323b7515ccffe86f255