### PR TITLE
Improve preview flag support and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ To run the QC and Microbial Profiles workflows, run:
 ```bash
 metagear qc_dna --input samples.csv
 metagear microbial_profiles --input samples.csv
+metagear qc_dna --input samples.csv -preview   # generate script only
 ```
+Running with `-preview` prints the generated script instead of executing it.
+The file `metagear_qc_dna.sh` will be created in the current directory and can
+be executed manually or the command can be re-run without `-preview`.
 
 The input file should look like this:
 ```

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ metagear microbial_profiles --input samples.csv
 metagear qc_dna --input samples.csv -preview   # generate script only
 ```
 Running with `-preview` prints the generated script instead of executing it.
-The file `metagear_qc_dna.sh` will be created in the current directory and can
-be executed manually or the command can be re-run without `-preview`.
+For instance when running `metagear qc_dna --input samples.csv -preview`, a file `metagear_qc_dna.sh` is generated in the current directory and can
+be executed manually, or the command can be re-run without `-preview` to directly run the pipeline.
 
 The input file should look like this:
 ```

--- a/main.sh
+++ b/main.sh
@@ -27,6 +27,21 @@ shift
 
 check_command "$COMMAND"
 
+# Detect preview mode and filter it from the arguments
+PREVIEW=false
+REMAINING_ARGS=()
+while (( $# > 0 )); do
+    case "$1" in
+        -preview|--preview)
+            PREVIEW=true
+            ;;
+        *)
+            REMAINING_ARGS+=("$1")
+            ;;
+    esac
+    shift
+done
+
 mkdir -p $LAUNCH_DIR/.metagear
 
 custom_config_files=( $PIPELINE_DIR/conf/metagear/$COMMAND.config $HOME/.metagear/metagear.config )
@@ -35,7 +50,7 @@ all_config_files=( "${metagear_config_files[@]}" "${custom_config_files[@]}" )
 
 $UTILITIES_DIR/lib/merge_configuration.sh ${all_config_files[@]} > $LAUNCH_DIR/.metagear/$COMMAND.config
 
-nf_cmd_workflow_part=$(run_workflows $COMMAND $@)
+nf_cmd_workflow_part=$(run_workflows $COMMAND "${REMAINING_ARGS[@]}")
 
 cat $HOME/.metagear/metagear.env > $LAUNCH_DIR/metagear_$COMMAND.sh
 
@@ -49,4 +64,12 @@ echo "" >> $LAUNCH_DIR/metagear_$COMMAND.sh
 
 chmod +x $LAUNCH_DIR/metagear_$COMMAND.sh
 
-$LAUNCH_DIR/metagear_$COMMAND.sh
+if [ "$PREVIEW" = true ]; then
+    echo "------ Preview mode ------"
+    cat "$LAUNCH_DIR/metagear_$COMMAND.sh"
+    echo "--------------------------"
+    echo "The script above was generated at $LAUNCH_DIR/metagear_$COMMAND.sh"
+    echo "Run it directly or re-run this command without the preview flag to execute."
+else
+    $LAUNCH_DIR/metagear_$COMMAND.sh
+fi

--- a/tests/preview.bats
+++ b/tests/preview.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env -S bats --shell /usr/bin/env bash
+
+setup() {
+  TEST_HOME="$BATS_TMPDIR/home"
+  mkdir -p "$TEST_HOME"
+  export HOME="$TEST_HOME"
+  mkdir -p "$HOME/.metagear/latest/conf/metagear"
+  cp "$BATS_TEST_DIRNAME/../templates/metagear.config" "$HOME/.metagear/metagear.config"
+  cp "$BATS_TEST_DIRNAME/../templates/metagear.env" "$HOME/.metagear/metagear.env"
+  touch "$HOME/.metagear/latest/conf/metagear/qc_dna.config"
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+@test "main.sh preview outputs script" {
+  cd "$BATS_TMPDIR"
+  echo -e "sample,fastq_1,fastq_2\nS1,a,b" > test.csv
+  run "$BATS_TEST_DIRNAME/../main.sh" qc_dna --input test.csv -preview
+  [ -f metagear_qc_dna.sh ]
+  [[ "$output" == *"Preview mode"* ]]
+  [[ "$output" == *"metagear_qc_dna.sh"* ]]
+}


### PR DESCRIPTION
## Summary
- document preview usage in README
- handle `--preview` flag in `main.sh`
- add Bats test for preview mode

## Testing
- `bats tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa2797838832380334d8cdc70fb8c