### PR TITLE
Add --dev option to installer

### DIFF
--- a/dev.md
+++ b/dev.md
@@ -29,3 +29,11 @@ The bulk of the functionality is implemented in Bash. `main.sh` calls the helper
 1. Install [Bats](https://bats-core.readthedocs.io/).
 2. Run `bats tests` to ensure helper functions behave as expected.
 3. Modify the scripts in `lib/` or the wrapper as needed.
+
+### Local pipeline development
+
+Developers can point the `latest` symlink to a local checkout of
+`metagear-pipeline` by passing the `--dev /path/to/pipeline` option to
+`install.sh`. The script still downloads the tagged pipeline version, but the
+`latest` link will reference the provided directory instead, allowing the
+wrapper to execute your local code.


### PR DESCRIPTION
## Summary
- add optional `--dev` argument to `install.sh`
- point `latest` symlink to provided directory when using `--dev`
- document new option in `dev.md`

## Testing
- `bats tests` *(fails: `[ -f metagear ]`)*

------
https://chatgpt.com/codex/tasks/task_e_68403d06de18832396cbe783463d3967