### PR TITLE
Add support for custom config per metagear run #15

### DIFF
--- a/lib/workflows.sh
+++ b/lib/workflows.sh
@@ -46,6 +46,10 @@ function run_workflows() {
                 shift
                 outdir="$1"
                 ;;
+            --config)
+                shift
+                config="$1"
+                ;;    
             *)
                 echo "Invalid option: $1"
                 usage
@@ -79,3 +83,32 @@ function run_workflows() {
     echo "--workflow $workflow --input $default_input_file --outdir $outdir"
 }
 
+function get_config() {
+    workflow="$1"
+    shift
+    
+    local config=""
+    
+    while (( $# > 0 )); do
+        case "$1" in
+            --input)
+                shift
+                input_file="$1"
+                ;;
+            --outdir)
+                shift
+                outdir="$1"
+                ;;
+            --config)
+                shift
+                config="$1"
+                ;;
+            *)
+                echo "Invalid option: $1"
+                usage
+                ;;
+        esac
+        shift
+    done
+    echo $config
+}

--- a/main.sh
+++ b/main.sh
@@ -29,7 +29,9 @@ check_command "$COMMAND"
 
 mkdir -p $LAUNCH_DIR/.metagear
 
-custom_config_files=( $PIPELINE_DIR/conf/metagear/$COMMAND.config $HOME/.metagear/metagear.config )
+argument_config_file=$(get_config $COMMAND $@)
+
+custom_config_files=( $PIPELINE_DIR/conf/metagear/$COMMAND.config $METAGEAR_DIR/metagear.config  $argument_config_file)
 metagear_config_files=( $PIPELINE_DIR/conf/metagear/*.config )
 all_config_files=( "${metagear_config_files[@]}" "${custom_config_files[@]}" )
 


### PR DESCRIPTION
This PR adds support for specifying a custom configuration file for a single metagear run, in addition to the default config located in the metagear home directory. (Issue #15  )

It introduces a new `--config` flag to supply an additional nextflow config file. The file is added to all the other configs and merged. The pull request should not change the default behaviour without the flag. 