### PR TITLE
Add relative links to env&config

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -73,8 +73,8 @@ check_requirements() {
 
 function check_metagear_home() {
 
-    user_config_file=$HOME/.metagear/metagear.config
-    user_env_file=$HOME/.metagear/metagear.env
+    user_config_file=$METAGEAR_DIR/metagear.config
+    user_env_file=$METAGEAR_DIR/metagear.env
 
     if [ ! -f $user_config_file ]; then
 
@@ -88,7 +88,7 @@ function check_metagear_home() {
         total_memory_gb=$(get_total_memory_gb)
         echo "Installed RAM: ${total_memory_gb} GB"
 
-        cp $HOME/.metagear/utilities/templates/metagear.config $user_config_file
+        cp $METAGEAR_DIR/utilities/templates/metagear.config $user_config_file
 
         # detect macOS vs Linux so we can pass the right -i flag
         if [[ "$(uname)" == "Darwin" ]]; then
@@ -116,7 +116,7 @@ function check_metagear_home() {
             "s|^databases_root = \".*\"|databases_root = \"${HOME}/.metagear/databases\"|" \
             "$user_config_file"
 
-        cp $HOME/.metagear/utilities/templates/metagear.env $user_env_file
+        cp $METAGEAR_DIR/utilities/templates/metagear.env $user_env_file
 
         echo ""
         echo "It seems this is the first time MetaGEAR runs in this system..."

--- a/main.sh
+++ b/main.sh
@@ -9,7 +9,8 @@ fi
 
 # Resolve script directory and source common functions
 UTILITIES_DIR="$(dirname "$(realpath "$0")")"
-PIPELINE_DIR="$HOME/.metagear/latest"
+METAGEAR_DIR="$(dirname "$UTILITIES_DIR")"
+PIPELINE_DIR="$METAGEAR_DIR/latest"
 LAUNCH_DIR="$PWD"
 
 source "${UTILITIES_DIR}/lib/common.sh"
@@ -29,7 +30,7 @@ check_command "$COMMAND"
 
 mkdir -p $LAUNCH_DIR/.metagear
 
-custom_config_files=( $PIPELINE_DIR/conf/metagear/$COMMAND.config $HOME/.metagear/metagear.config )
+custom_config_files=( $PIPELINE_DIR/conf/metagear/$COMMAND.config $METAGEAR_DIR/metagear.config )
 metagear_config_files=( $PIPELINE_DIR/conf/metagear/*.config )
 all_config_files=( "${metagear_config_files[@]}" "${custom_config_files[@]}" )
 
@@ -37,7 +38,7 @@ $UTILITIES_DIR/lib/merge_configuration.sh ${all_config_files[@]} > $LAUNCH_DIR/.
 
 nf_cmd_workflow_part=$(run_workflows $COMMAND $@)
 
-cat $HOME/.metagear/metagear.env > $LAUNCH_DIR/metagear_$COMMAND.sh
+cat $METAGEAR_DIR/metagear.env > $LAUNCH_DIR/metagear_$COMMAND.sh
 
 echo "" >> $LAUNCH_DIR/metagear_$COMMAND.sh
 echo "nextflow run $PIPELINE_DIR/main.nf \\


### PR DESCRIPTION
Installing metagear to a custom location leads to errors due to hardcoded paths in main.sh and utilities/common.sh. I changed them to allow runs from non ~/.metagear/ locations.